### PR TITLE
Add batch script to list large files with sorting

### DIFF
--- a/scripts/list_large_files.bat
+++ b/scripts/list_large_files.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Usage: %~nx0 ^<path_or_drive^>
+    exit /b 1
+)
+
+set "TARGET=%~1"
+
+for %%I in ("%TARGET%") do set "RESOLVED=%%~fI"
+
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  "& { param([string]$target)" ^
+  "    try {" ^
+  "        if (-not (Test-Path -LiteralPath $target)) {" ^
+  "            Write-Error \"The specified path '$target' does not exist.\"; exit 1" ^
+  "        }" ^
+  "        $limit = 2GB;" ^
+  "        $files = Get-ChildItem -LiteralPath $target -File -Recurse -ErrorAction Stop |" ^
+  "                 Where-Object { $_.Length -ge $limit } |" ^
+  "                 ForEach-Object {" ^
+  "                     [PSCustomObject]@{" ^
+  "                         DirectoryPath = $_.DirectoryName;" ^
+  "                         DirectoryCreationTime = $_.Directory.CreationTime;" ^
+  "                         FullPath = $_.FullName;" ^
+  "                         SizeBytes = $_.Length;" ^
+  "                         CreationTime = $_.CreationTime;" ^
+  "                         LastWriteTime = $_.LastWriteTime" ^
+  "                     }" ^
+  "                 } |" ^
+  "                 Sort-Object DirectoryCreationTime, CreationTime, @{ Expression = { $_.SizeBytes }; Descending = $true };" ^
+  "        if (-not $files) {" ^
+  "            Write-Host \"No files larger than 2 GB were found in $target.\";" ^
+  "            exit 0" ^
+  "        }" ^
+  "        $files | Select-Object FullPath," ^
+  "                          @{ Name = 'Size (GB)'; Expression = { '{0:N2}' -f ($_.SizeBytes / 1GB) } }," ^
+  "                          @{ Name = 'Creation Time'; Expression = { $_.CreationTime } }," ^
+  "                          @{ Name = 'Last Modified'; Expression = { $_.LastWriteTime } } |" ^
+  "                 Format-Table -AutoSize" ^
+  "    } catch {" ^
+  "        Write-Error $_;" ^
+  "        exit 1" ^
+  "    }" ^
+  "  }" -args "%RESOLVED%"
+set "ERR=%ERRORLEVEL%"
+endlocal & exit /b %ERR%


### PR DESCRIPTION
## Summary
- add a Windows batch script that lists files larger than 2 GB under a target path
- use PowerShell to sort results by directory age, file age, and size before formatting the output

## Testing
- pytest *(fails: missing dependency `torch` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb98be8900832da1166c5d2d7c7bf7